### PR TITLE
Fixed wrong frequency for PWM signal

### DIFF
--- a/MotorDRV/motor_drv.sv
+++ b/MotorDRV/motor_drv.sv
@@ -12,8 +12,8 @@ module motor_drv
 	output logic pwm_outB
 );
 
-	localparam integer CLK_DIV = clk_hz / pwm_hz;			// Calculating max number for clock divider (clock_counter)
-	logic [$clog2(CLK_DIV)-1:0] clock_counter = 0;			// Calculating bit width for clock divider (clock_counter) to get 250 Hz frequency after dividing
+	localparam integer CLK_DIV = clk_hz / (256 *  pwm_hz);			// Calculating max number for clock divider (clock_counter)
+	logic [$clog2(CLK_DIV)-1:0] clock_counter = 0;			// Calculating bit width for clock divider (clock_counter) to get 64 kHz frequency after dividing
 	logic [7:0] pwm_counter = 0;
 
 	always_ff @(posedge clk or posedge rst) begin
@@ -24,13 +24,13 @@ module motor_drv
 			clock_counter <= clock_counter + 1;
 			if (clock_counter == CLK_DIV - 1) begin		// Resetting clock_counter after it gets to the max number (CLK_DIV - 1)
 				clock_counter <= 0;
-				pwm_counter <= pwm_counter + 1;		// Adding +1 to the pwm_counter to reach 250 Hz frequency for PWM signal
+				pwm_counter <= pwm_counter + 1;		// Adding +1 to the pwm_counter to reach 250 Hz frequency for PWM signal (64 kHz for pwm_counter)
 			end
 		end
 	end
 
 	logic pwm;							
-	assign pwm = (pwm_counter < duty_cycle);			// Getting PWM signal
+	assign pwm = (pwm_counter < duty_cycle);			// Getting PWM signal (250 Hz)
 	assign pwm_outA = direction ? pwm : 0;				// Setting the PWM signal to one of the outputs based on the direction variable
 	assign pwm_outB = direction ? 0 : pwm;
 

--- a/MotorDRV/top.sv
+++ b/MotorDRV/top.sv
@@ -1,6 +1,6 @@
 module top (
 	input logic clk25,		// Declaring inputs and outputs according to the configuration file (karnix_cabga256.lpf)
-	input logic [2:0] key,
+	input logic [3:0] key,
 	output logic [1:0] led
 );
 	


### PR DESCRIPTION
Поменял частоту выходного ШИМ, чтобы она соответствовала ТЗ (250 Гц).
Когда закончил писать модуль, к несчастью не заметил этот момент, устал уже :(
У вас вроде бы осциллограф есть, может посмотреть как сигнал выглядит. Вроде сейчас должно быть правильно :)
У меня на светодиодах не особо видно, но моргать стало точно чаще. Но глаз уже не различает отдельные моргания. Однако по моим прикидкам частота сигнала должна быть pwm_hz при коэфф заполнения 50%. Т.е. длина импульса около 1/500 секунды. 